### PR TITLE
fix: disabled fullchain textarea editing in SSL details

### DIFF
--- a/src/components/SSLCertificateModal.jsx
+++ b/src/components/SSLCertificateModal.jsx
@@ -32,7 +32,7 @@ export default function SSLCertificateModal({
               {privateKey}
             </Textarea>
             <Text>Fullchain</Text>
-            <Textarea height={500}>
+            <Textarea height={500} variant="filled" readOnly>
               {fullchain}
             </Textarea>
 


### PR DESCRIPTION
Fixes #40 

#### Describe the changes you have made in this PR -

- disabled the fullchain textarea in the SSL certificate details modal

### Screenshots of the changes (If any) -

![ssl-texarea-disable](https://github.com/swiftwave-org/swiftwave-dashboard/assets/75930195/8a22df9c-a733-47da-8659-9f5d66ae6e26)
