### PR TITLE
feat: automatic refresh of the ingress and redirect rules page

### DIFF
--- a/src/pages/ingress_rules.jsx
+++ b/src/pages/ingress_rules.jsx
@@ -23,7 +23,12 @@ import {
 import { SyncIcon } from "@primer/octicons-react";
 import { useContext, useEffect, useState } from "react";
 import ControllerContext from "../context/controller/ControllerContext";
-import { formatReadableDate, showErrorToast, showSuccessToast } from "../utils";
+import {
+  formatReadableDate,
+  showErrorToast,
+  showSuccessToast,
+  runTaskAtInterval,
+} from "../utils";
 import tag_color from "../config/tag_color";
 import { AddIcon } from "@chakra-ui/icons";
 import AddIngressRulesModal from "../components/addIngressRulesModal";
@@ -94,6 +99,8 @@ export default function IngressRulesPage() {
 
   useEffect(() => {
     fetchRules();
+    const intervalID = runTaskAtInterval(fetchRules, 10000);
+    return () => clearInterval(intervalID);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/pages/redirect_rules.jsx
+++ b/src/pages/redirect_rules.jsx
@@ -22,7 +22,12 @@ import {
 import { SyncIcon } from "@primer/octicons-react";
 import { useContext, useEffect, useState } from "react";
 import ControllerContext from "../context/controller/ControllerContext";
-import { formatReadableDate, showErrorToast, showSuccessToast } from "../utils";
+import {
+  formatReadableDate,
+  showErrorToast,
+  showSuccessToast,
+  runTaskAtInterval,
+} from "../utils";
 import tag_color from "../config/tag_color";
 import { AddIcon } from "@chakra-ui/icons";
 import AddRedirectRulesModal from "../components/addRedirectRulesModal";
@@ -77,9 +82,8 @@ export default function RedirectRulesPage() {
 
   useEffect(() => {
     fetchRules();
-    setInterval(() => {
-      fetchRules();
-    }, 10000);
+    const intervalID = runTaskAtInterval(fetchRules, 10000);
+    return () => clearInterval(intervalID);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,3 +35,12 @@ export function showSuccessToast(toast, message){
     position: "top"
   });
 }
+
+export function runTaskAtInterval(callback, interval) {
+  const intervalId = setInterval(() => {
+    callback(); // Call the provided callback function
+  }, interval);
+
+  // Return the interval ID in case you want to clear it later
+  return intervalId;
+}


### PR DESCRIPTION
Fixes #30 
Fixes #32

#### Describe the changes you have made in this PR -
Added Utility function to refresh data after every 10 seconds and used in ingress rules page.
There are two refresh calls happening after every 10 seconds in redirect rules page, because of multiple re renders. Used this utility function to fix that.


### Screenshots of the changes (If any) -


Note: Please check **Allow edits from maintainers.** before creating the PR. 
