### PR TITLE
feat: auto-rectify git source url 

### DIFF
--- a/src/context/controller/_applicationController.js
+++ b/src/context/controller/_applicationController.js
@@ -93,8 +93,7 @@ export default class ApplicationController {
   // Generate docker config
   // from git
   async generateDockerConfigFromGit(git_credential_id, repository_url, branch) {
-    // const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
-    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
     const new_repo_url = repository_url.replace(pattern, '$1');
     console.log(new_repo_url);
 

--- a/src/context/controller/_applicationController.js
+++ b/src/context/controller/_applicationController.js
@@ -93,6 +93,10 @@ export default class ApplicationController {
   // Generate docker config
   // from git
   async generateDockerConfigFromGit(git_credential_id, repository_url, branch) {
+    const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    const new_repo_url = repository_url.replace(pattern, '$1');
+    console.log(new_repo_url);
+
     try {
       const res = await axios({
         method: "post",
@@ -101,7 +105,7 @@ export default class ApplicationController {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         data: qs.stringify({
-          'repository_url': repository_url,
+          'repository_url': new_repo_url,
           'branch': branch,
           'git_credential_id': git_credential_id
         })

--- a/src/context/controller/_applicationController.js
+++ b/src/context/controller/_applicationController.js
@@ -93,10 +93,6 @@ export default class ApplicationController {
   // Generate docker config
   // from git
   async generateDockerConfigFromGit(git_credential_id, repository_url, branch) {
-    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
-    const new_repo_url = repository_url.replace(pattern, '$1');
-    console.log(new_repo_url);
-
     try {
       const res = await axios({
         method: "post",
@@ -105,7 +101,7 @@ export default class ApplicationController {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         data: qs.stringify({
-          'repository_url': new_repo_url,
+          'repository_url': repository_url,
           'branch': branch,
           'git_credential_id': git_credential_id
         })

--- a/src/context/controller/_applicationController.js
+++ b/src/context/controller/_applicationController.js
@@ -93,7 +93,8 @@ export default class ApplicationController {
   // Generate docker config
   // from git
   async generateDockerConfigFromGit(git_credential_id, repository_url, branch) {
-    const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    // const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
     const new_repo_url = repository_url.replace(pattern, '$1');
     console.log(new_repo_url);
 

--- a/src/context/controller/_gitCredentialsController.js
+++ b/src/context/controller/_gitCredentialsController.js
@@ -109,15 +109,10 @@ export default class GitCredentialsController {
 
   // test git credential
   async testAccess(id, repo_url, branch) {
-    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
-    const new_repo_url = repo_url.replace(pattern, '$1');
-    console.log(repo_url) // https://github.com/avelynhc/til_tracker/tree/main
-    console.log(new_repo_url) // https://github.com/avelynhc/til_tracker
-
     try {
       const res = await axios({
         method: "get",
-        url: route.GIT_CREDENTIALS + "/" + id + "/test?repository_url=" + new_repo_url+"&branch="+branch,
+        url: route.GIT_CREDENTIALS + "/" + id + "/test?repository_url=" + repo_url+"&branch="+branch,
       })
       return {
         status: true,

--- a/src/context/controller/_gitCredentialsController.js
+++ b/src/context/controller/_gitCredentialsController.js
@@ -109,8 +109,7 @@ export default class GitCredentialsController {
 
   // test git credential
   async testAccess(id, repo_url, branch) {
-    // const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
-    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
     const new_repo_url = repo_url.replace(pattern, '$1');
     console.log(repo_url) // https://github.com/avelynhc/til_tracker/tree/main
     console.log(new_repo_url) // https://github.com/avelynhc/til_tracker

--- a/src/context/controller/_gitCredentialsController.js
+++ b/src/context/controller/_gitCredentialsController.js
@@ -112,7 +112,7 @@ export default class GitCredentialsController {
     try {
       const res = await axios({
         method: "get",
-        url: route.GIT_CREDENTIALS + "/" + id + "/test?repository_url=" + repo_url+"&branch="+branch,
+        url: route.GIT_CREDENTIALS + "/" + id + "/test?repository_url=" + repo_url + "&branch="+branch,
       })
       return {
         status: true,

--- a/src/context/controller/_gitCredentialsController.js
+++ b/src/context/controller/_gitCredentialsController.js
@@ -109,7 +109,8 @@ export default class GitCredentialsController {
 
   // test git credential
   async testAccess(id, repo_url, branch) {
-    const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    // const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
     const new_repo_url = repo_url.replace(pattern, '$1');
     console.log(repo_url) // https://github.com/avelynhc/til_tracker/tree/main
     console.log(new_repo_url) // https://github.com/avelynhc/til_tracker

--- a/src/context/controller/_gitCredentialsController.js
+++ b/src/context/controller/_gitCredentialsController.js
@@ -109,10 +109,15 @@ export default class GitCredentialsController {
 
   // test git credential
   async testAccess(id, repo_url, branch) {
+    const pattern = /^(https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/main$/;
+    const new_repo_url = repo_url.replace(pattern, '$1');
+    console.log(repo_url) // https://github.com/avelynhc/til_tracker/tree/main
+    console.log(new_repo_url) // https://github.com/avelynhc/til_tracker
+
     try {
       const res = await axios({
         method: "get",
-        url: route.GIT_CREDENTIALS + "/" + id + "/test?repository_url=" + repo_url+"&branch="+branch,
+        url: route.GIT_CREDENTIALS + "/" + id + "/test?repository_url=" + new_repo_url+"&branch="+branch,
       })
       return {
         status: true,

--- a/src/pages/deploy_application/configure_source.jsx
+++ b/src/pages/deploy_application/configure_source.jsx
@@ -47,6 +47,7 @@ export default function ConfigureSourcePage({
   const uploadCodeFieldRef = useRef(null);
   const tarballRef = useRef(null);
   const dockerfileModalDisclosure = useDisclosure();
+  const [inputField, setInputField] = useState({url: ""})
 
   // Is configuration generating
   const [isConfigurationGenerating, setIsConfigurationGenerating] =
@@ -267,6 +268,7 @@ export default function ConfigureSourcePage({
     const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
     formRef.current.repository_url = original_url.replace(pattern, '$1');
     console.log(formRef.current.repository_url)
+    setInputField({...inputField, url: formRef.current.repository_url})
   }
 
   useEffect(() => {
@@ -333,6 +335,7 @@ export default function ConfigureSourcePage({
                 <Input
                   placeholder="Git Repo URL"
                   onChange={rectifyGitRepoUrlHandler}
+                  value={inputField.url}
                 />
               </FormControl>
               <FormControl isRequired>

--- a/src/pages/deploy_application/configure_source.jsx
+++ b/src/pages/deploy_application/configure_source.jsx
@@ -262,6 +262,13 @@ export default function ConfigureSourcePage({
     dockerfileModalDisclosure.onOpen();
   };
 
+  const rectifyGitRepoUrlHandler = (e) => {
+    const original_url = e.target.value;
+    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
+    formRef.current.repository_url = original_url.replace(pattern, '$1');
+    console.log(formRef.current.repository_url)
+  }
+
   useEffect(() => {
     fetchGitCredentials();
   }, []);
@@ -325,9 +332,7 @@ export default function ConfigureSourcePage({
                 <FormLabel>Git Repo URL</FormLabel>
                 <Input
                   placeholder="Git Repo URL"
-                  onChange={(e) =>
-                    (formRef.current.repository_url = e.target.value)
-                  }
+                  onChange={rectifyGitRepoUrlHandler}
                 />
               </FormControl>
               <FormControl isRequired>

--- a/src/pages/deploy_application/configure_source.jsx
+++ b/src/pages/deploy_application/configure_source.jsx
@@ -47,7 +47,7 @@ export default function ConfigureSourcePage({
   const uploadCodeFieldRef = useRef(null);
   const tarballRef = useRef(null);
   const dockerfileModalDisclosure = useDisclosure();
-  const [inputField, setInputField] = useState({url: ""})
+  const inputRef = useRef(null);
 
   // Is configuration generating
   const [isConfigurationGenerating, setIsConfigurationGenerating] =
@@ -267,7 +267,7 @@ export default function ConfigureSourcePage({
     const original_url = e.target.value;
     const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(\w+)$/;
     formRef.current.repository_url = original_url.replace(pattern, '$1');
-    setInputField({...inputField, url: formRef.current.repository_url})
+    inputRef.current.value = formRef.current.repository_url;
   }
 
   useEffect(() => {
@@ -334,7 +334,7 @@ export default function ConfigureSourcePage({
                 <Input
                   placeholder="Git Repo URL"
                   onChange={rectifyGitRepoUrlHandler}
-                  value={inputField.url}
+                  ref={inputRef}
                 />
               </FormControl>
               <FormControl isRequired>

--- a/src/pages/deploy_application/configure_source.jsx
+++ b/src/pages/deploy_application/configure_source.jsx
@@ -265,9 +265,8 @@ export default function ConfigureSourcePage({
 
   const rectifyGitRepoUrlHandler = (e) => {
     const original_url = e.target.value;
-    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(?:main|master)$/;
+    const pattern = /^(https:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/tree\/(\w+)$/;
     formRef.current.repository_url = original_url.replace(pattern, '$1');
-    console.log(formRef.current.repository_url)
     setInputField({...inputField, url: formRef.current.repository_url})
   }
 


### PR DESCRIPTION
Fixes #36 

#### Describe the changes you have made in this PR 
- added regex to replace extended GitHub URL (i.e., https://github.com/avelynhc/til_tracker/tree/main) with the accepted version (i.e., https://github.com/avelynhc/til_tracker).
- it can now accept the following URLs: GitHub, GitLab, and BitBucket.
- it can accept either "main" or "master" in the URL.

### Screenshots of the changes (If any) -
<img width="994" alt="Screenshot 2023-09-29 at 2 08 42 PM" src="https://github.com/swiftwave-org/swiftwave-dashboard/assets/75185537/a05f577d-9142-418a-ba26-417f8fe341a8">