### PR TITLE
fix: resource monitor version (bump to 2.0.1)

### DIFF
--- a/src/views/partials/SetupResourceMonitoring.vue
+++ b/src/views/partials/SetupResourceMonitoring.vue
@@ -94,13 +94,13 @@ const fetchAnalyticsServiceToken = async (rotate = false) => {
                 echo "deb [signed-by=/etc/apt/keyrings/swiftwave.gpg] http://deb.repo.swiftwave.org/
                 swiftwave-stats-ninja stable" | sudo tee /etc/apt/sources.list.d/swiftwave-stats-ninja.list<br />
                 sudo apt update<br />
-                sudo apt install swiftwave-stats-ninja=2.0.0
+                sudo apt install swiftwave-stats-ninja=2.0.1
               </Code>
               <div class="my-4"></div>
               <p class="font-medium">For Fedora/CentOS/Almalinux/RockyLinux users,</p>
               <Code
                 >sudo dnf config-manager --add-repo http://rpm.repo.swiftwave.org/swiftwave.repo<br />
-                sudo dnf install -y swiftwave-stats-ninja-2.0.0-1
+                sudo dnf install -y swiftwave-stats-ninja-2.0.1-1
               </Code>
             </div>
           </Step>


### PR DESCRIPTION
Updated the install command in the instructions for swiftwave-stats-ninja -> 2.0.1