### PR TITLE
fix: remove console.log leaking env vars in ApplicationGroupDetails

### DIFF
--- a/src/views/pages/ApplicationGroupDetails.vue
+++ b/src/views/pages/ApplicationGroupDetails.vue
@@ -283,7 +283,6 @@ const isAnyAppInfoChanged = computed(() => {
 
 // Environment Variables Editor Related
 const environmentVariableKeys = (app) => {
-  console.log(environmentVariableDetails)
   return environmentVariableDetails[app.id].keys
 }
 const environmentVariableMap = (app) => {


### PR DESCRIPTION
## Summary
- Elimina `console.log(environmentVariableDetails)` en `environmentVariableKeys()` de `ApplicationGroupDetails.vue` que exponía el objeto completo de variables de entorno (incluyendo valores potencialmente sensibles como secrets, API keys, credenciales de DB) en la consola del navegador cada vez que se renderizaba la lista de keys.

## Why
Las variables de entorno suelen contener información sensible. Loguearlas al `console` del navegador las hace visibles a cualquiera con acceso a DevTools y puede dejar rastros en herramientas de monitoreo del lado cliente.